### PR TITLE
fix(api): revoke visitors access to API, document basic-auth

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -8,7 +8,9 @@ User=__APP__
 Group=__APP__
 WorkingDirectory=__INSTALL_DIR__/
 ExecStart=__INSTALL_DIR__/prometheus \
-  --config.file=__INSTALL_DIR__/prometheus.yml --web.enable-admin-api \
+  --config.file=__INSTALL_DIR__/prometheus.yml \
+  --web.config.file=__INSTALL_DIR__/web.yml \
+  --web.enable-admin-api \
   --web.external-url=__PATH__/ \
   --web.route-prefix=__PATH__/ \
   --web.listen-address=localhost:__PORT__

--- a/conf/web.yml
+++ b/conf/web.yml
@@ -1,0 +1,2 @@
+basic_auth_users:
+    __ADMIN__: __HASH__

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,1 +1,7 @@
 You can configure the app in the file `__INSTALL_DIR__/prometheus.yml` and then restarting the app service by running `sudo systemctl restart __APP__.service`.
+
+# API and authentication
+
+It is heavily discouraged to grant Visitors access to the API. By default, no authentication would be required and the metrics could be accessible to anyone.
+
+Check the [app's documentation](https://prometheus.io/docs/guides/basic-auth/) to learn how to set up credentials before opening the API.

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,2 +1,8 @@
 Vous pouvez configurer l'application dans le fichier `__INSTALL_DIR__/prometheus.yml`,
 puis en redémarrant le service de l'appli en lançant `sudo systemctl restart __APP__.service`.
+
+# API et authentification
+
+Il est fortement déconseillé d'accorder aux visiteurs l'accès à l'API. Par défaut, aucune authentification ne serait requise et les métriques seraient accessibles à tout le monde.
+
+Consultez la [documentation de l'application](https://prometheus.io/docs/guides/basic-auth/) pour savoir comment configurer les identifiants avant d'ouvrir l'API.

--- a/doc/PRE_UPGRADE.d/3.13.1~ynh1.md
+++ b/doc/PRE_UPGRADE.d/3.13.1~ynh1.md
@@ -1,0 +1,5 @@
+It is quite probable that your Prometheus instance has its API endpoint completely open.
+
+Sorry about that! This version brings you to v3.13.1 and closes the API by default.
+
+If you want to allow authentication by visitors, check out its configuration page in the YunoHost webadmin beforehand.

--- a/manifest.toml
+++ b/manifest.toml
@@ -40,6 +40,16 @@ ram.runtime = "50M"
     type = "path"
     default = "/prometheus"
 
+    [install.init_main_permission]
+    type = "group"
+    default = "admins"
+
+    [install.init_api_permission]
+    type = "group"
+    default = "admins"
+    help.en = "Choose which group can access the API. If you select `visitors` without further action, the API and metrics will be completely open. This is not recommended, read the app's configuration page after installation to set up credentials."
+    help.fr = "Choisissez quel groupe peut accéder à l'API. Si vous sélectionnez `visiteurs` sans d'autre action, alors l'API et les métriques seront complètement ouvertes. Cela n'est pas recommandé, consultez la page de configuration de l'app après installation pour mettre en place des authentifiants."
+
 [resources]
     [resources.sources]
     [resources.sources.main]
@@ -67,11 +77,9 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
-    main.allowed = "admins"
 
     api.url = "/api"
     api.show_tile = false
-    api.allowed = "visitors"
 
     [resources.ports]
     main.default = 9090

--- a/scripts/install
+++ b/scripts/install
@@ -24,7 +24,7 @@ ynh_script_progression "Configuring the app..."
 ynh_replace --match="localhost:9090" --replace="localhost:$port" --file="$install_dir/prometheus.yml"
 echo "    metrics_path: $path/metrics" >> "$install_dir/prometheus.yml"
 
-ynh_config_add --template="web.yml" --destination="$install_dir/web.yml"
+#ynh_config_add --template="web.yml" --destination="$install_dir/web.yml"
 
 #=================================================
 # SYSTEM CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -24,6 +24,8 @@ ynh_script_progression "Configuring the app..."
 ynh_replace --match="localhost:9090" --replace="localhost:$port" --file="$install_dir/prometheus.yml"
 echo "    metrics_path: $path/metrics" >> "$install_dir/prometheus.yml"
 
+ynh_config_add --template="web.yml" --destination="$install_dir/web.yml"
+
 #=================================================
 # SYSTEM CONFIGURATION
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -14,6 +14,12 @@ ynh_systemctl --service=$app --action="stop" --log_path="systemd"
 #=================================================
 ynh_script_progression "Ensuring downward compatibility..."
 
+if ynh_app_upgrading_from_version_before 3.13.1~ynh1; then
+    ynh_permission_has_user --permission=api --user=visitors && ynh_permission_update --permission "api" --remove="visitors"
+    ynh_print_warn "Visitors permission to the API has been revoked, cf. pre-upgrade message and app's documentation."
+fi
+
+[ ! -f "$install_dir/web.yml" ] && ynh_config_add --template="web.yml" --destination="$install_dir/web.yml"
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================


### PR DESCRIPTION
The current configuration makes the API and metrics completely open if Visitors have the API permission

## Solution

- [x] revoke visitors access to API
- [x] document basic-auth if there is a need to reinstate the visitors acccess

:warning: This does not work properly, and breaks the webapp access (it is also covered by the app's basic auth...).
This needs to be fixed and properly documented. Maybe add a configuration panel?

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
